### PR TITLE
Fallback to default locale message if it is not present in selected locale

### DIFF
--- a/languages/zh_CN.json
+++ b/languages/zh_CN.json
@@ -1,6 +1,7 @@
 {
     "hello": {
         "world": "你好，世界！",
-        "somebody": "你好，{{name}}！"
+        "somebody": "你好，{{name}}！",
+        "this_locale_only": "仅存在于 zh_CN"
     }
 }


### PR DESCRIPTION
If requested message is not present in selected locale and fallback is enabled, try to get the message from default locale.